### PR TITLE
Marketplace docs + ownership migration (publisher AllanZiolkowski)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,16 @@ When the user asks to bump the version (e.g. "update the vsix version", "increme
 1. Update `"version"` in `package.json`
 2. Run `npm run compile` to rebuild with the new version baked in (splash screen reads it)
 3. Run `npm run package` (`vsce package`) to produce the `.vsix` file
-4. Commit both `package.json` and the new `.vsix` file together
+4. Commit `package.json` (and any source changes) — **do not** try to commit the `.vsix`; it is gitignored (see below)
+5. Tag the release: `git tag -a v{version} -m "..."` and push the tag, so each shipped `.vsix` maps to an exact commit
 
-`npm run package` = `vsce package` — produces `ceramic-mark-{version}.vsix` in the project root. This is the file distributed to beta users.
+`npm run package` = `vsce package` — produces `ceramic-mark-{version}.vsix` in the project root.
+
+**The `.vsix` is NOT committed to git.** `*.vsix` is gitignored and never has been tracked. There is no CI release workflow — packaging and publishing are manual. The git tag (step 5) is what ties a distributed `.vsix` back to its source commit.
+
+CeramicMark is published on the **Visual Studio Marketplace** (publisher `beyondidentity`, listing `beyondidentity.ceramic-mark`). Publishing is done **manually** — uploading the `.vsix` via the Marketplace publisher portal (there is no `vsce publish` automation in this repo). The same `.vsix` may also be shared out-of-band (Slack / shared drive) for beta builds ahead of a Marketplace upload.
+
+Releasing is therefore: (a) get the code into the repo via a PR to `main` (work happens on feature branches; never push straight to `main`), then (b) build + tag the `.vsix` and upload it to the Marketplace. Note `gh` may default to a pull-only account — pushing/PRs against `gobeyondidentity/ceramicmark` require the `aziolk-beyond` collaborator account (`gh auth switch --user aziolk-beyond`).
 
 Launch for development: `Fn+F5` in VS Code opens an Extension Development Host.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,9 @@ When the user asks to bump the version (e.g. "update the vsix version", "increme
 
 **The `.vsix` is NOT committed to git.** `*.vsix` is gitignored and never has been tracked. There is no CI release workflow — packaging and publishing are manual. The git tag (step 5) is what ties a distributed `.vsix` back to its source commit.
 
-CeramicMark is published on the **Visual Studio Marketplace** (publisher `beyondidentity`, listing `beyondidentity.ceramic-mark`). Publishing is done **manually** — uploading the `.vsix` via the Marketplace publisher portal (there is no `vsce publish` automation in this repo). The same `.vsix` may also be shared out-of-band (Slack / shared drive) for beta builds ahead of a Marketplace upload.
+CeramicMark is published on the **Visual Studio Marketplace** (publisher `AllanZiolkowski`, listing `AllanZiolkowski.ceramic-mark`). Publishing is done **manually** — uploading the `.vsix` via the Marketplace publisher portal (there is no `vsce publish` automation in this repo). The manifest `publisher` in `package.json` **must** match the signed-in Marketplace publisher or the portal rejects the upload. The same `.vsix` may also be shared out-of-band (Slack / shared drive) for beta builds ahead of a Marketplace upload.
 
-Releasing is therefore: (a) get the code into the repo via a PR to `main` (work happens on feature branches; never push straight to `main`), then (b) build + tag the `.vsix` and upload it to the Marketplace. Note `gh` may default to a pull-only account — pushing/PRs against `gobeyondidentity/ceramicmark` require the `aziolk-beyond` collaborator account (`gh auth switch --user aziolk-beyond`).
+Releasing is therefore: (a) get the code into the repo via a PR to `main` (work happens on feature branches; never push straight to `main`), then (b) build + tag the `.vsix` and upload it to the Marketplace. The repo lives at `aziolkowskiux/ceramicmark_plugin` (personal account) — it was migrated from the former `gobeyondidentity/ceramicmark` org, so the publisher changed from `beyondidentity` accordingly. `gh` has multiple accounts logged in; if a push/PR is denied, switch to the account that owns the repo (`gh auth switch --user aziolkowskiux`).
 
 Launch for development: `Fn+F5` in VS Code opens an Extension Development Host.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Click any element in the running app to anchor a comment to it. No switching too
 
 ---
 
+## Install
+
+Install from the Visual Studio Marketplace: search **CeramicMark** in the Extensions view (`Cmd+Shift+X`), or visit the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=beyondidentity.ceramic-mark). Works in VS Code and Cursor.
+
+To run from source instead, see [Dev setup](#dev-setup-running-from-source) below.
+
+---
+
 ## How it works
 
 1. Open any project in VS Code or Cursor
@@ -76,7 +84,7 @@ Browser mode requires a Chromium-family browser (Chrome, Edge, or Chromium) inst
 
 ## Dev setup (running from source)
 
-Use this if CeramicMark isn't on the marketplace yet and you need to run it locally.
+Use this if you want to run the latest unreleased code, or develop CeramicMark itself, rather than installing from the Marketplace.
 
 **Requirements:** Node.js, VS Code, and (for Browser mode) Chrome/Edge/Chromium
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Click any element in the running app to anchor a comment to it. No switching too
 
 ## Install
 
-Install from the Visual Studio Marketplace: search **CeramicMark** in the Extensions view (`Cmd+Shift+X`), or visit the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=beyondidentity.ceramic-mark). Works in VS Code and Cursor.
+Install from the Visual Studio Marketplace: search **CeramicMark** in the Extensions view (`Cmd+Shift+X`), or visit the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=AllanZiolkowski.ceramic-mark). Works in VS Code and Cursor.
 
 To run from source instead, see [Dev setup](#dev-setup-running-from-source) below.
 
@@ -90,7 +90,7 @@ Use this if you want to run the latest unreleased code, or develop CeramicMark i
 
 1. Clone the repo and open it in VS Code:
    ```bash
-   git clone https://github.com/gobeyondidentity/ceramicmark
+   git clone https://github.com/aziolkowskiux/ceramicmark_plugin
    cd ceramic-mark
    code .
    ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "CeramicMark",
   "description": "Figma-style visual comment pins on live UI previews, inside your IDE.",
   "version": "0.2.1",
-  "publisher": "beyondidentity",
+  "publisher": "AllanZiolkowski",
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -138,7 +138,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gobeyondidentity/ceramicmark"
+    "url": "https://github.com/aziolkowskiux/ceramicmark_plugin"
   },
   "dependencies": {
     "ws": "^8.21.0"


### PR DESCRIPTION
Rolls up the Marketplace-availability docs and the ownership migration from `gobeyondidentity` to the personal account.

## Changes
- **Publisher migration** — `package.json` publisher `beyondidentity` → `AllanZiolkowski` (the manifest publisher must match the signed-in Marketplace publisher; the old one was rejected on upload). `repository.url` → `aziolkowskiux/ceramicmark_plugin`.
- **README** — added an **Install** section (Marketplace search + listing link), updated the listing link and clone URL, reworded the stale "not on the marketplace yet" dev-setup note.
- **CLAUDE.md** — corrected the release flow: `.vsix` is gitignored (commit source + tag, don't commit the artifact); manual Marketplace upload under publisher `AllanZiolkowski`; repo now at `aziolkowskiux/ceramicmark_plugin`; `gh` account note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)