### PR TITLE
Rename extension to ceramicmark-plugin (Marketplace name collision)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ When the user asks to bump the version (e.g. "update the vsix version", "increme
 4. Commit `package.json` (and any source changes) — **do not** try to commit the `.vsix`; it is gitignored (see below)
 5. Tag the release: `git tag -a v{version} -m "..."` and push the tag, so each shipped `.vsix` maps to an exact commit
 
-`npm run package` = `vsce package` — produces `ceramic-mark-{version}.vsix` in the project root.
+`npm run package` = `vsce package` — produces `ceramicmark-plugin-{version}.vsix` in the project root.
 
 **The `.vsix` is NOT committed to git.** `*.vsix` is gitignored and never has been tracked. There is no CI release workflow — packaging and publishing are manual. The git tag (step 5) is what ties a distributed `.vsix` back to its source commit.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ceramic-mark",
+  "name": "ceramicmark-plugin",
   "displayName": "CeramicMark",
   "description": "Figma-style visual comment pins on live UI previews, inside your IDE.",
   "version": "0.2.1",


### PR DESCRIPTION
## Problem
Marketplace upload rejected: `The extension 'ceramic-mark' already exists in the Marketplace.` The `name` identifier must be globally unique across the whole Marketplace, and `ceramic-mark` was already claimed by the former `beyondidentity` listing.

## Fix
Rename `name` `ceramic-mark` → `ceramicmark-plugin`. New listing ID: `AllanZiolkowski.ceramicmark-plugin`.

- `displayName` stays **"CeramicMark"** — no change to what users see.
- `ceramicMark.*` command/view IDs are independent of the package name, so nothing at runtime changes.
- Updated the packaged `.vsix` filename reference in CLAUDE.md (`ceramicmark-plugin-{version}.vsix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)