### PR TITLE
Rename displayName to "CeramicMark Plugin" (Marketplace uniqueness)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceramicmark-plugin",
-  "displayName": "CeramicMark",
+  "displayName": "CeramicMark Plugin",
   "description": "Figma-style visual comment pins on live UI previews, inside your IDE.",
   "version": "0.2.1",
   "publisher": "AllanZiolkowski",


### PR DESCRIPTION
Marketplace requires a globally-unique `displayName`; "CeramicMark" was still held by the old `beyondidentity` listing. Set it to "CeramicMark Plugin" (consistent with the `ceramicmark-plugin` name). No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)